### PR TITLE
fix: _research() returns failure when no newSkill — unblocks researchFailed escalation

### DIFF
--- a/kernel.js
+++ b/kernel.js
@@ -1198,6 +1198,9 @@ Decide HOW to execute. Respond with JSON:
     if (findings.newPatterns) for (const p of findings.newPatterns) await this.memory.upsertPattern(p);
     if (findings.newSkill) await this.memory.addSkill(findings.newSkill);
 
+    if (!findings.newSkill) {
+      return { success: false, error: 'no skill acquired', type: 'research', findings };
+    }
     return { success: true, type: 'research', findings };
   }
 


### PR DESCRIPTION
## Summary
Fixes GitHub issue #13.

**Bug:** `_research()` always returned `{ success: true }` when the LLM responded normally — even when `newSkill` was null. The `researchFailed → escalate` path was completely dead code.

**Fix:** Return `{ success: false }` when LLM returns no `newSkill`. This unblocks the skill-gap escalation path — the human gets notified instead of looping until `maxCycles`.

**Changes:** kernel.js, +3 lines

**Testing:** `node --check kernel.js` passes, `node example.js` runs successfully