### PR TITLE
fix: _enqueue — increment _activeCount before awaiting _run to prevent TOCTOU race

### DIFF
--- a/kernel.js
+++ b/kernel.js
@@ -119,25 +119,33 @@ class ActivationHarness {
 
   async _enqueue(trigger) {
     if (this._activeCount < this.maxConcurrent) {
-      await this._run(trigger);
+      this._activeCount++;
+      this._run(trigger).finally(() => {
+        this._activeCount--;
+        this._processQueue();
+      });
     } else {
       this._queue.push(trigger);
     }
   }
 
   async _run(trigger) {
-    this._activeCount++;
     try {
       const result = await this.kernel.activate(trigger);
       this.onResult(result, trigger);
     } catch (err) {
       this.onError(err, trigger);
-    } finally {
-      this._activeCount--;
-      if (this._queue.length > 0 && this._activeCount < this.maxConcurrent) {
-        const next = this._queue.shift();
-        await this._run(next);
-      }
+    }
+  }
+
+  _processQueue() {
+    if (this._queue.length > 0 && this._activeCount < this.maxConcurrent) {
+      const next = this._queue.shift();
+      this._activeCount++;
+      this._run(next).finally(() => {
+        this._activeCount--;
+        this._processQueue();
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixes GitHub issue #11.

**Bug:** `ActivationHarness._enqueue()` checked `this._activeCount < this.maxConcurrent` then awaited `_run(trigger)`, which incremented `_activeCount` inside. Two near-simultaneous `emit()` calls could both pass the check before either incremented — violating `maxConcurrent`.

**Fix:** Increment `_activeCount` atomically in `_enqueue` *before* calling `_run`. Queue draining extracted into a new `_processQueue()` method with the same atomic pattern.

**Changes:** kernel.js, +16/-8 lines in `ActivationHarness`

**Testing:** `node --check kernel.js` passes, `node example.js` runs successfully